### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#iOSSwiftMetalCamera
+# iOSSwiftMetalCamera
 
 [Click here to see video demo.](https://www.youtube.com/watch?v=cM1ncSkGMUs)
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
